### PR TITLE
SortImports.hs: Don't add a newline before EOF.

### DIFF
--- a/code/SortImports.hs
+++ b/code/SortImports.hs
@@ -166,9 +166,8 @@ convert style@Style{..} modules source = T.unlines . concat $ [
   , map (showImport style) first_import_group
   , separator_if $ not $ null first_import_group
   , map (showImport style) second_import_group
-  , separator_if $ not $ null second_import_group
-  , rest
-  ]
+  , separator_if $ ((not . null $ second_import_group) && (not . null $ rest))
+  , rest ]
   where
     (header, body) = break is_import . T.lines $ source
     (import_section, rest) = span (T.null <||> is_import <||> is_indented) body


### PR DESCRIPTION
Previously, when a module consisted only of import/reexport
statements, `SortImports.hs` would add a spurious newline before the end
of file.